### PR TITLE
Added Xcode 6.4 compatibility UUID.

### DIFF
--- a/ProjectWindowName/Info.plist
+++ b/ProjectWindowName/Info.plist
@@ -32,6 +32,7 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
Xcode 6.4 has a new compatibility UUID, so I added it to the info.plist.

Thanks for a great plugin :) It's been my dream since I started working with Xcode.
